### PR TITLE
Resolve environment variables in path names

### DIFF
--- a/test/test_linter.py
+++ b/test/test_linter.py
@@ -113,6 +113,10 @@ class LinterTest(unittest.TestCase):
         cmake_abs_env = '$ENV{CATKIN_LINT_ABS_TESTVAR}'
         self.assertEqual('/wheee', info.resolve_env_vars(cmake_abs_env))
         self.assertEqual('/wheee', info.real_path(cmake_abs_env))
+        os.environ['CATKIN_LINT_PARTIAL_TESTVAR'] = 'CATKIN_LINT_'
+        os.environ['CATKIN_LINT_SUFFIX'] = 'REL_TESTVAR'
+        cmake_nested_env = '$ENV{$ENV{CATKIN_LINT_PARTIAL_TESTVAR}$ENV{CATKIN_LINT_SUFFIX}}'
+        self.assertEqual('wheee', info.resolve_env_vars(cmake_nested_env))
 
     @patch("os.path.isfile", lambda x: x == os.path.normpath("/mock-path/broken.cmake"))
     def do_blacklist(self):


### PR DESCRIPTION
As discussed in #25, resolve environment variables when checking paths.

Also added a test to ensure the feature works as desired.