### PR TITLE
Escape double quotes

### DIFF
--- a/src/catkin_lint/cmake.py
+++ b/src/catkin_lint/cmake.py
@@ -72,6 +72,8 @@ _token_spec = [
     ( 'SEMICOLON', r';'),
     ( 'WORD', r'[^\(\)"# \t\r\n;]+' ),
     ( 'PRAGMA', r'#catkin_lint:.*?$' ),
+    ( 'BACKSLASH', r"\\"),
+    ( 'DOUBLE_QUOTATION', r'\"'),
     ( 'COMMENT', r'#.*?$' ),
 ]
 _next_token = re.compile('|'.join('(?P<%s>%s)' % pair for pair in _token_spec), re.MULTILINE | re.IGNORECASE).match

--- a/src/catkin_lint/cmake.py
+++ b/src/catkin_lint/cmake.py
@@ -99,7 +99,7 @@ def _lexer(s):
         pos = mo.end()
         mo = _next_token(s, pos)
     if pos != len(s):
-        raise SyntaxError("Unexpected character %r on line %d" % (s[pos], line))
+        raise SyntaxError("Unexpected character %r on line %d [%s]" % (s[pos], line, s.split('\n')[line-1]))
 
 
 def _resolve_args(arg_tokens, var, env_var):


### PR DESCRIPTION
I am faced with a following problem.

Following line in CMakeLists.txt
```
add_definitions(-DHRPSYS_PACKAGE_VERSION="\"${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}.${CPACK_PACKAGE_VERSION_PATCH}\\"\")
```

```
iory: $ catkin_lint 
catkin_lint: cannot lint hrpsys_gazebo_general: Unexpected character '"' on line 6 [add_definitions(-DHRPSYS_PACKAGE_VERSION=\"\\"${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}.${CPACK_PACKAGE_VERSION_PATCH}\\"\")]
catkin_lint: checked 1 packages and found 0 problems
```

If we apply this patch, we can solve problem.
