### PR TITLE
fix handling of hidden folders

### DIFF
--- a/src/catkin_lint/environment.py
+++ b/src/catkin_lint/environment.py
@@ -78,9 +78,8 @@ def find_packages(basepath, use_cache=True):
             package_paths.append(os.path.relpath(dirpath, basepath))
             del dirnames[:]
             continue
-        for dirname in dirnames:
-            if dirname.startswith('.'):
-                dirnames.remove(dirname)
+        # filter out hidden directories in-place
+        dirnames[:] = [d for d in dirnames if not d.startswith('.')]
     cache_updated = False
     for path in package_paths:
         pkg_dir = os.path.realpath(os.path.join(basepath, path))


### PR DESCRIPTION
It took me some time to spot the problem.
Finally, I figured that I have fixed this issue before (https://github.com/ros-infrastructure/catkin_pkg/pull/183).

Is there any reason for not using `find_package_paths` from `catkin_pkg`?
(https://github.com/fkie/catkin_lint/compare/master...ipa-mdl:find_package_paths?expand=1)