### PR TITLE
Evaluate conditions in package manifests according to REP 149

### DIFF
--- a/src/catkin_lint/checks/manifest.py
+++ b/src/catkin_lint/checks/manifest.py
@@ -38,22 +38,22 @@ from .misc import project
 
 def depends(linter):
     def on_init(info):
-        info.buildtool_dep = set([dep.name for dep in info.manifest.buildtool_depends])
-        info.build_dep = set([dep.name for dep in info.manifest.build_depends])
+        info.buildtool_dep = {dep.name for dep in info.manifest.buildtool_depends if dep.evaluated_condition}
+        info.build_dep = {dep.name for dep in info.manifest.build_depends if dep.evaluated_condition}
         info.export_dep = set()
         info.exec_dep = set()
         if info.manifest.package_format > 1:
-            deps = set([dep.name for dep in info.manifest.build_export_depends])
+            deps = {dep.name for dep in info.manifest.build_export_depends if dep.evaluated_condition}
             info.export_dep.update(deps)
-            deps = set([dep.name for dep in info.manifest.buildtool_export_depends])
+            deps = {dep.name for dep in info.manifest.buildtool_export_depends if dep.evaluated_condition}
             info.export_dep.update(deps)
-            deps = set([dep.name for dep in info.manifest.exec_depends])
+            deps = {dep.name for dep in info.manifest.exec_depends if dep.evaluated_condition}
             info.exec_dep.update(deps)
         if info.manifest.package_format < 2:
-            deps = set([dep.name for dep in info.manifest.run_depends])
+            deps = {dep.name for dep in info.manifest.run_depends if dep.evaluated_condition}
             info.export_dep.update(deps)
             info.exec_dep.update(deps)
-        info.test_dep = set([dep.name for dep in info.manifest.test_depends])
+        info.test_dep = {dep.name for dep in info.manifest.test_depends if dep.evaluated_condition}
         if info.env.ok:
             for pkg in info.buildtool_dep | info.build_dep | info.export_dep | info.exec_dep | info.test_dep:
                 if not info.env.is_known_pkg(pkg):

--- a/src/catkin_lint/environment.py
+++ b/src/catkin_lint/environment.py
@@ -94,6 +94,8 @@ def find_packages(basepath, use_cache=True):
         packages[path] = manifest
     if cache_updated:
         _store_cache()
+    for package in packages.values():
+        package.evaluate_conditions(os.environ)
     return packages
 
 

--- a/test/helper.py
+++ b/test/helper.py
@@ -43,7 +43,7 @@ def create_env(catkin_pkgs=["catkin", "message_generation", "message_runtime", "
 
 
 def create_manifest(name, description="", buildtool_depends=["catkin"], build_depends=[], run_depends=[], test_depends=[], meta=False):
-    return Package(
+    package = Package(
         name=name,
         version="0.0.0",
         package_format=1,
@@ -55,10 +55,12 @@ def create_manifest(name, description="", buildtool_depends=["catkin"], build_de
         test_depends=[Dependency(d) for d in test_depends],
         exports=[Export("metapackage")] if meta else []
     )
+    package.evaluate_conditions({})
+    return package
 
 
 def create_manifest2(name, description="", buildtool_depends=["catkin"], build_depends=[], depends=[], buildtool_export_depends=[], build_export_depends=[], exec_depends=[], test_depends=[], meta=False):
-    return Package(
+    package = Package(
         name=name,
         version="0.0.0",
         package_format=2,
@@ -73,6 +75,8 @@ def create_manifest2(name, description="", buildtool_depends=["catkin"], build_d
         test_depends=[Dependency(d) for d in test_depends],
         exports=[Export("metapackage")] if meta else []
     )
+    package.evaluate_conditions({})
+    return package
 
 
 def mock_lint(env, manifest, cmakelist, checks=all, indentation=False, return_var=False, package_path=None):

--- a/test/test_checks_manifest.py
+++ b/test/test_checks_manifest.py
@@ -173,7 +173,7 @@ class ChecksManifestTest(unittest.TestCase):
         result = mock_lint(env, pkg, "", checks=cc.package_description)
         self.assertEqual([], result)
 
-    def test_bla(self):
+    def test_evaluate_conditions(self):
         """Test if dependency conditions are properly evaluated"""
 
         # suppose we have a python2 system

--- a/test/test_checks_manifest.py
+++ b/test/test_checks_manifest.py
@@ -1,7 +1,10 @@
-import unittest
 import os
 import sys
+import unittest
+from catkin_pkg.package import Package, Dependency
+
 import catkin_lint.checks.manifest as cc
+
 from .helper import create_env, create_manifest, create_manifest2, mock_lint, mock_open, patch, posix_and_nt
 
 
@@ -168,4 +171,23 @@ class ChecksManifestTest(unittest.TestCase):
         self.assertEqual(["DESCRIPTION_MEANINGLESS"], result)
         pkg = create_manifest("mock", description="Mock Cool Worf")
         result = mock_lint(env, pkg, "", checks=cc.package_description)
+        self.assertEqual([], result)
+
+    def test_bla(self):
+        """Test if dependency conditions are properly evaluated"""
+
+        # suppose we have a python2 system
+        env = create_env(system_pkgs=['python-yaml'])
+
+        # and a package that is dual python2 & 3 compatible
+        pkg = Package(
+            name="mock",
+            package_format=3,
+            exec_depends=[Dependency('python-yaml', condition='$ROS_PYTHON_VERSION == 2'),
+                          Dependency('python3-yaml', condition='$ROS_PYTHON_VERSION == 3')],
+        )
+        pkg.evaluate_conditions({'ROS_PYTHON_VERSION': 2})
+
+        # then the lint should not complain about a missing python3-yaml
+        result = mock_lint(env, pkg, "", checks=cc.depends)
         self.assertEqual([], result)


### PR DESCRIPTION
I've been migrating my code to noetic and python3 and I've been using conditions to manage the dependencies of a package, for example:
```xml
<exec_depend condition="$ROS_PYTHON_VERSION == 2">python-netifaces</exec_depend>
<exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-netifaces</exec_depend>
```
It seems that `catkin_lint` doesn't support these. At the moment is doesn't evaluate conditions and so it will complain that the python3 packages do not exist or the way around.

This PR implements evaluating the conditions at check time, such that the errors will be properly displayed.