### PR TITLE
Handle elseif()

### DIFF
--- a/test/test_indentation.py
+++ b/test/test_indentation.py
@@ -142,7 +142,7 @@ class IndentationTest(unittest.TestCase):
             """, checks=None, indentation=True)
 
     def test_if(self):
-        """Test indentation check for if()/else()/endif() blocks"""
+        """Test indentation check for if()/elseif()/else()/endif() blocks"""
         env = create_env()
         pkg = create_manifest("mock")
         result = mock_lint(env, pkg,
@@ -150,6 +150,7 @@ class IndentationTest(unittest.TestCase):
                 cmd()
                 if()
                     cmd()
+                elseif()
                     cmd()
                 else()
                     cmd()
@@ -162,6 +163,7 @@ class IndentationTest(unittest.TestCase):
         result = mock_lint(env, pkg,
                            """
                 if()
+                elseif()
                 else()
                 endif()
             """, checks=None, indentation=True)
@@ -170,6 +172,9 @@ class IndentationTest(unittest.TestCase):
         result = mock_lint(env, pkg,
                            """
                 if()
+                    if()
+                    endif()
+                elseif()
                     if()
                     endif()
                 else()
@@ -194,6 +199,16 @@ class IndentationTest(unittest.TestCase):
                     cmd()
                     cmd()
                     endif()
+            """, checks=None, indentation=True)
+        self.assertEqual(["INDENTATION"], result)
+
+        result = mock_lint(env, pkg,
+                           """
+                if()
+                    cmd()
+                    elseif()
+                    cmd()
+                endif()
             """, checks=None, indentation=True)
         self.assertEqual(["INDENTATION"], result)
 

--- a/test/test_linter.py
+++ b/test/test_linter.py
@@ -166,6 +166,16 @@ class LinterTest(unittest.TestCase):
             project(mock)
             find_package(catkin REQUIRED)
             catkin_package()
+            if(true)
+            elseif (${var} STREQUAL "foo")
+            endif()
+            """, checks=cc.all)
+        self.assertEqual(["UNQUOTED_STRING_OP"], result)
+        result = mock_lint(env, pkg,
+                           """
+            project(mock)
+            find_package(catkin REQUIRED)
+            catkin_package()
             if ("foo" STREQUAL ${var})
             endif()
             """, checks=cc.all)
@@ -212,6 +222,17 @@ class LinterTest(unittest.TestCase):
             endif()
             """, checks=cc.all)
         self.assertEqual(["AMBIGUOUS_CONDITION"], result)
+        result = mock_lint(env, pkg,
+                           """
+            project(mock)
+            find_package(catkin REQUIRED)
+            catkin_package()
+            if(true)
+            elseif (${varname})
+            endif()
+            """, checks=cc.all)
+        self.assertEqual(["AMBIGUOUS_CONDITION"], result)
+
         result = mock_lint(env, pkg,
                            """
             project(mock)


### PR DESCRIPTION
Not sure if it deserves more special handling to track in `info.conditionals`, but it seems to work ok to treat `elseif()` like `if()`- keeping in draft until some feedback is received.

Without the elseif handling elseif is treated like a regular cmake line and generates the `notice: line is not indented properly` warning.