### PR TITLE
Fix location of rosdep cache dir

### DIFF
--- a/src/catkin_lint/ros.py
+++ b/src/catkin_lint/ros.py
@@ -57,9 +57,11 @@ class Rosdep(object):
 def get_rosdep(quiet):
     from rosdep2.lookup import RosdepLookup
     from rosdep2.rospkg_loader import DEFAULT_VIEW_KEY
-    from rosdep2.sources_list import SourcesListLoader
+    from rosdep2.sources_list import SourcesListLoader, SOURCES_CACHE_DIR
     dummy = DummyRospkg()
-    sources_loader = SourcesListLoader.create_default(sources_cache_dir=os.environ.get("ROSDEP_CACHE_PATH", None))
+    rosdep_cache_dir = os.environ.get("ROSDEP_CACHE_PATH", None)
+    sources_cache_dir = os.path.join(rosdep_cache_dir, SOURCES_CACHE_DIR) if rosdep_cache_dir is not None else None
+    sources_loader = SourcesListLoader.create_default(sources_cache_dir=sources_cache_dir)
     lookup = RosdepLookup.create_from_rospkg(rospack=dummy, rosstack=dummy, sources_loader=sources_loader)
     return Rosdep(view=lookup.get_rosdep_view(DEFAULT_VIEW_KEY), quiet=quiet)
 


### PR DESCRIPTION
catkin_lint internally uses rosdep to check for existence of packages mentioned in package.xml. When running tests on ROS buildfarm, rosdep database is unfortunately not inited or updated, so any rosdep lookups fail. And [there is no way to tell the buildfarm to init and update the db before running tests](https://github.com/ros-infrastructure/ros_buildfarm/issues/923#issuecomment-962229414).

So currently, any code that wants to use catkin_lint in `run_tests` and should be released via ROS buildfarm, needs to do some non-trivial checks to see if there is a rosdep database cache, and in case there isn't, catkin_lint has to be disabled (or at least checking package existence should be disabled via a flag).

One way around this limitation is using a custom (non-root writable) location for the rosdep db and cache and downloading the cache files again every time the tests are run (this can be later optimized via CI cache storage, if the folder name is predictable).

So this PR is a first step towards making it possible to use catkin_lint on ROS buildfarm. The other part would be implemented in the CMake calling code (and I'm thinking about submitting another PR with the CMake support similar to https://github.com/tue-robotics/catkin_lint_cmake).