### PR TITLE
Handle changed ntpath.isabs behaviour in Python 3.13 (#110)

### DIFF
--- a/src/catkin_lint/checks/build.py
+++ b/src/catkin_lint/checks/build.py
@@ -30,6 +30,7 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import ntpath
 import os
 import posixpath
 import stat
@@ -394,7 +395,7 @@ def exports(linter):
         if ext_includes:
             info.report(ERROR, "EXTERNAL_INCLUDE_PATH")
         info.export_libs |= set(opts["LIBRARIES"])
-        info.export_includes |= set([d for d in includes if not os.path.isabs(d)])
+        info.export_includes |= set([d for d in includes if not posixpath.isabs(d) and not ntpath.isabs(d)])
         info.export_packages |= set(opts["CATKIN_DEPENDS"])
         info.export_targets |= set(opts["EXPORTED_TARGETS"])
 


### PR DESCRIPTION
ntpath.isabs no longer considers paths that start with "/" to be absolute. This is correct behaviour on Windows but causes us problems, because our `PathConstants` use paths that start with / and expect these to always be considered absolute. To deal with this, let's just filter out paths that are absolute by ntpath *or* posixpath rules.