### PR TITLE
Handle changed ntpath.isabs behaviour in Python 3.13 (#110)

### DIFF
--- a/src/catkin_lint/linter.py
+++ b/src/catkin_lint/linter.py
@@ -74,11 +74,11 @@ class PathClass(object):
 
 
 class PathConstants(object):
-    PACKAGE_SOURCE = "/%s" % generate_random_id()
-    PACKAGE_BINARY = "/%s" % generate_random_id()
-    CATKIN_DEVEL = "/%s" % generate_random_id()
-    CATKIN_INSTALL = "/%s" % generate_random_id()
-    DISCOVERED_PATH = "/%s" % generate_random_id()
+    PACKAGE_SOURCE = "//%s" % generate_random_id()
+    PACKAGE_BINARY = "//%s" % generate_random_id()
+    CATKIN_DEVEL = "//%s" % generate_random_id()
+    CATKIN_INSTALL = "//%s" % generate_random_id()
+    DISCOVERED_PATH = "//%s" % generate_random_id()
 
 
 class LintInfo(object):

--- a/test/test_checks_build.py
+++ b/test/test_checks_build.py
@@ -1113,7 +1113,7 @@ class ChecksBuildTest(unittest.TestCase):
             find_package(other_catkin REQUIRED)
             catkin_package(
             CATKIN_DEPENDS other_catkin
-            INCLUDE_DIRS /not/in/package
+            INCLUDE_DIRS //not/in/package
             )
             """,
                            checks=cc.exports)

--- a/test/test_linter.py
+++ b/test/test_linter.py
@@ -247,8 +247,8 @@ class LinterTest(unittest.TestCase):
         self.assertEqual(info.source_relative_path("subdir/filename"), "subdir/filename")
         self.assertEqual(info.source_relative_path("subdir/../filename"), "filename")
         self.assertEqual(info.source_relative_path("/filename"), "/filename")
-        self.assertEqual(info.source_relative_path("../../../../filename"), "/filename")
-        self.assertEqual(info.source_relative_path("../../../../subdir/filename"), "/subdir/filename")
+        self.assertEqual(info.source_relative_path("../../../../filename"), "//filename")
+        self.assertEqual(info.source_relative_path("../../../../subdir/filename"), "//subdir/filename")
         info.var = {
             "CMAKE_CURRENT_SOURCE_DIR": "%s/subdir" % PathConstants.PACKAGE_SOURCE,
         }


### PR DESCRIPTION
ntpath.isabs no longer considers paths that start with "/" to be absolute. This is correct behaviour on Windows but causes us problems, because our `PathConstants` use paths that start with / and expect these to always be considered absolute. To deal with this, let's add an extra slash to the `PathConstants`; paths starting `//` are considered absolute by both ntpath and posixpath.

This is an alternative to #111 , it probably doesn't make sense to do both.